### PR TITLE
fix zmk firmware builds on mac (darwin)

### DIFF
--- a/nix/zephyr/builder.nix
+++ b/nix/zephyr/builder.nix
@@ -6,73 +6,86 @@
 , gcc-arm-embedded
 , git
 , python3
+,
 }:
-
 let
   west = python3.withPackages (ps: [ ps.west ps.pyelftools ]);
 in
-
-{
-  zephyrDepsHash ? "",
-  westBuildFlags ? [],
-  ...
-} @ args: stdenv.mkDerivation (finalAttrs: (lib.attrsets.removeAttrs args [ "zephyrDepsHash" "westRoot" ]) // {
+{ zephyrDepsHash ? ""
+, westBuildFlags ? [ ]
+, ...
+} @ args:
+stdenv.mkDerivation (finalAttrs:
+(lib.attrsets.removeAttrs args [ "zephyrDepsHash" "westRoot" ])
+  // {
   inherit westBuildFlags;
 
-  nativeBuildInputs = [
-    cmake
-    git
-    ninja
-    west
-  ] ++ (args.nativeBuildInputs or []);
+  nativeBuildInputs =
+    [
+      cmake
+      git
+      ninja
+      west
+    ]
+    ++ (args.nativeBuildInputs or [ ]);
 
-  westDeps = args.westDeps or (fetchZephyrDeps ({
-    name = "${finalAttrs.finalPackage.name}-west-deps";
-    hash = zephyrDepsHash;
-  }
-  // (lib.filterAttrs (name: _: lib.elem name [ "westRoot" ]) args)
-  // (lib.filterAttrs (name: _: lib.elem name [ "src" "srcs" "sourceRoot" "prePatch" "patches" "postPatch" ]) finalAttrs)));
+  westDeps =
+    args.westDeps
+      or (fetchZephyrDeps ({
+      name = "${finalAttrs.finalPackage.name}-west-deps";
+      hash = zephyrDepsHash;
+    }
+    // (lib.filterAttrs (name: _: lib.elem name [ "westRoot" ]) args)
+    // (lib.filterAttrs (name: _: lib.elem name [ "src" "srcs" "sourceRoot" "prePatch" "patches" "postPatch" ]) finalAttrs)));
 
   passthru = { inherit (finalAttrs.westDeps) westRoot; };
 
-  env = {
-    ZEPHYR_TOOLCHAIN_VARIANT = "gnuarmemb";
-    GNUARMEMB_TOOLCHAIN_PATH = gcc-arm-embedded;
-  } // (args.env or {});
+  env =
+    {
+      ZEPHYR_TOOLCHAIN_VARIANT = "gnuarmemb";
+      GNUARMEMB_TOOLCHAIN_PATH = gcc-arm-embedded;
+    }
+    // (args.env or { });
 
-  configurePhase = args.configurePhase or ''
-    for output in $westDeps/.west $westDeps/*; do
-      cp --no-preserve=mode -rt . "$output"
-    done
+  configurePhase =
+    args.configurePhase
+      or ''
+      for output in $westDeps/.west $westDeps/*; do
+        cp --no-preserve=mode -rt . "$output"
+      done
 
-    declare -ag westBuildFlagsArray=(${lib.escapeShellArgs finalAttrs.westBuildFlags})
+      declare -ag westBuildFlagsArray=(${lib.escapeShellArgs finalAttrs.westBuildFlags})
 
-    if zephyrRoot="$(dirname "$(dirname "$(find "$(pwd)" -path '*/share/zephyr-package/cmake' -printf '%h' -quit)")")"; then
-      addCMakeParams "$zephyrRoot"
+      if zephyrRoot="$(dirname "$(dirname "$(find "$(pwd)" -path '*/share/zephyr-package/cmake' -printf '%h' -quit)")")"; then
+        addCMakeParams "$zephyrRoot"
 
-      if [ -z "$dontAddZephyrVersion" ]; then
-        if (for item in "''${westBuildFlagsArray[@]}"; do [ "$item" = '--' ] && exit 1; done); then
-          westBuildFlagsArray+=('--')
+        if [ -z "$dontAddZephyrVersion" ]; then
+          if (for item in "''${westBuildFlagsArray[@]}"; do [ "$item" = '--' ] && exit 1; done); then
+            westBuildFlagsArray+=('--')
+          fi
+          westBuildFlagsArray+=("-DBUILD_VERSION=$(<"$zephyrRoot"/.git/HEAD)")
         fi
-        westBuildFlagsArray+=("-DBUILD_VERSION=$(<"$zephyrRoot"/.git/HEAD)")
       fi
-    fi
 
-    runHook preConfigure
+      westBuildFlagsArray+=("-DZMK_CONFIG=$TMP/$sourceRoot/${finalAttrs.westDeps.westRoot}")
 
-    west build -d "''${cmakeBuildDir:=build}" --cmake-only "''${westBuildFlagsArray[@]}"
+      runHook preConfigure
 
-    cd "$cmakeBuildDir"
+      west build -d "''${cmakeBuildDir:=build}" --cmake-only "''${westBuildFlagsArray[@]}"
 
-    runHook postConfigure
-  '';
+      cd "$cmakeBuildDir"
 
-  installPhase = args.installPhase or ''
-    runHook preInstall
+      runHook postConfigure
+    '';
 
-    mkdir $out
-    cp */*.uf2 $out/
+  installPhase =
+    args.installPhase
+      or ''
+      runHook preInstall
 
-    runHook postInstall
-  '';
+      mkdir $out
+      cp */*.uf2 $out/
+
+      runHook postInstall
+    '';
 })

--- a/nix/zmk/keyboard.nix
+++ b/nix/zmk/keyboard.nix
@@ -1,25 +1,30 @@
 { lib
 , buildZephyrPackage
 , runCommand
-}:
-
-{ board
-, shield
-, src
-, zephyrDepsHash
-, name ? "zmk"
-, config ? "config"
-, extraCmakeFlags ? []
-, ... } @ args: buildZephyrPackage ((lib.attrsets.removeAttrs args [ "config" "extraCmakeFlags" ]) // {
+,
+}: { board
+   , shield
+   , src
+   , zephyrDepsHash
+   , name ? "zmk"
+   , config ? "config"
+   , extraCmakeFlags ? [ ]
+   , ...
+   } @ args:
+buildZephyrPackage ((lib.attrsets.removeAttrs args [ "config" "extraCmakeFlags" ])
+  // {
   inherit name;
 
   westRoot = config;
 
-  westBuildFlags = [
-    "-s" "zmk/app"
-    "-b" board
-    "--"
-    "-DZMK_CONFIG=/build/${src.name or "source"}/${config}"
-    "-DSHIELD=${shield}"
-  ] ++ extraCmakeFlags;
+  westBuildFlags =
+    [
+      "-s"
+      "zmk/app"
+      "-b"
+      board
+      "--"
+      "-DSHIELD=${shield}"
+    ]
+    ++ extraCmakeFlags;
 })


### PR DESCRIPTION
Sorry for the formatting changes which make the actual changes here harder to spot - if you can let me know what formatter you are using I can use it here (this is nixpkgs-fmt).

Without all the formatting this add the following line into `builder.nix:70`
```
westBuildFlagsArray+=("-DZMK_CONFIG=$TMP/$sourceRoot/${finalAttrs.westDeps.westRoot}")
```

And removes the following line from `keyboard.nix:22
```
 "-DZMK_CONFIG=/build/${src.name or "source"}/${config}"
```

This makes the paths work on darwin, because the `/build` directory is not where nix puts tmp build stuff on darwin.