### PR TITLE
nix/flash: fix abort when keyboard does not mount immediately

### DIFF
--- a/nix/flash.nix
+++ b/nix/flash.nix
@@ -48,8 +48,7 @@ writeShellApplication {
 
       sleep 1
 
-      mountpoint="$(mounted)"
-      if [ -z "$mountpoint" ]; then
+      if ! mountpoint="$(mounted)"; then
         echo -n "Please mount the mass storage device at $device so that the firmware file can be copied"
         while ! mountpoint="$(mounted)"; do
           echo -n .


### PR DESCRIPTION
Thanks for this project! I found the docker system that zmk publishes to be opaque - I like the nix setup better. And the flash script makes flashing so much easier!

I ran into one problem: on my system the keyboard mass storage does not mount automatically, and the flash script aborts because `mounted` returns a non-zero exit status. With this change the script proceeds to the "Please mount mass storage device" prompt if the storage is not mounted.