### PR TITLE
Add block-based flash method for UF2 bootloaders

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,10 @@
         inherit firmware;
       };
 
+      flashBlock = pkgs.callPackage ./nix/flash-block.nix {
+        inherit firmware;
+      };
+
       uf2-udev-rules = pkgs.callPackage ./nix/uf2-udev-rules {};
 
       update = pkgs.callPackage ./nix/update.nix {};

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,11 @@
           - Run `nix run .#update` to update West dependencies, including ZMK version, and bump the `zephyrDepsHash` on the derivation
           - GitHub Actions to automatically PR flake lockfile bumps and West dependency bumps are included
           - Using something like Mergify to automatically merge these PRs is recommended - see <https://github.com/lilyinstarlight/zmk-nix/blob/main/.github/mergify.yml> for an example Mergify configuration
+
+
+          ## Alternative flashers
+
+          - See the readme for alternative flash methods and their use.
         '';
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -20,10 +20,18 @@
         inherit firmware;
       };
 
+      uf2-udev-rules = pkgs.callPackage ./nix/uf2-udev-rules {};
+
       update = pkgs.callPackage ./nix/update.nix {};
     });
 
     legacyPackages = forAllSystems (system: self.lib.buildersFor nixpkgs.legacyPackages.${system});
+
+    nixosModules = {
+      udevRules = ({pkgs, ...}: {
+        services.udev.packages = [ self.packages.${pkgs.system}.uf2-udev-rules ];
+      });
+    };
 
     overlays = {
       default = final: prev: self.lib.buildersFor prev;

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
 
     nixosModules = {
       udevRules = ({pkgs, ...}: {
-        services.udev.packages = [ self.packages.${pkgs.system}.uf2-udev-rules ];
+        services.udev.packages = [ self.packages.${pkgs.stdenv.hostPlatform.system}.uf2-udev-rules ];
       });
     };
 

--- a/nix/flash-block.nix
+++ b/nix/flash-block.nix
@@ -1,0 +1,148 @@
+{ lib
+, writeShellApplication
+, coreutils
+, util-linux
+, findutils
+, firmware
+}:
+
+writeShellApplication {
+  name = "zmk-uf2-block-flash";
+
+  runtimeInputs = [
+    coreutils
+    findutils
+    util-linux
+  ];
+
+  text = ''
+    declare -a uf2devices
+
+    function banner {
+      echo "############################################################"
+      echo "### $1"
+      echo "############################################################"
+      echo
+    }
+
+    function updateUF2Devices {
+      uf2devices=()
+      while IFS= read -r device; do
+        uf2devices+=("$device")
+      done < <(find /dev/mapper -maxdepth 1 -name 'uf2_bootloader_*' -print)
+    }
+
+    banner "UF2 Block Flasher"
+
+    if [ "$EUID" -eq 0 ]; then
+      echo "This script should not be run as root."
+      exit 1
+    fi
+
+    updateUF2Devices
+    if [ "''${#uf2devices[@]}" -gt 0 ]; then
+      banner "Pre-flash warning"
+      echo "Found available UF2 devices, if you have not already put your"
+      echo "device into bootloader mode, then this may be a different device"
+      echo "than expected.  Press <CTRL>+<C> to stop."
+      echo
+      for device in "''${uf2devices[@]}"; do
+        echo " * $device"
+      done
+      echo
+      echo "Waiting for 5 seconds before continuing"
+      for _ in $(seq 5); do
+        echo -n "."
+        sleep 1
+      done
+      echo
+      echo "Continuing"
+    fi
+
+    flash=("$@")
+    parts=(${toString firmware.parts or ""})
+
+    if [ "''${#flash[@]}" -eq 0 ]; then
+      if [ "''${#parts[@]}" -eq 0 ]; then
+        flash=("")
+      else
+        flash=("''${parts[@]}")
+      fi
+    else
+      for part in "''${flash[@]}"; do
+        if ! printf '%s\0' "''${parts[@]}" | grep -Fxqz -- "$part"; then
+          echo "The '$part' part does not exist in the firmware '"'${firmware.name}'"'"
+          exit 1
+        fi
+      done
+    fi
+
+    for part in "''${flash[@]}"; do
+      banner "Flashing $part"
+      echo "Place device into bootloader mode and connect to via USB to begin flashing"
+      echo -n "Waiting for device: "
+      while :; do
+        updateUF2Devices
+        case "''${#uf2devices[@]}" in
+          0)
+            echo -n "."
+            sleep 1
+            continue
+            ;;
+          1)
+            echo
+            flashDevice="''${uf2devices[0]}"
+            break
+            ;;
+          *)
+            echo "ERROR: Multiple UF2 devices found, cannot determine which one to flash"
+            echo "Flashing terminated, exiting"
+            exit 1
+            ;;
+        esac
+      done
+
+      deviceFirmwareFile=(${firmware}/*"$([ -n "$part" ] && echo "_$part")".uf2)
+      if [ "''${#deviceFirmwareFile[@]}" -ne 1 ]; then
+        echo "Unexpected error, multiple firmware files globbed"
+        exit 2
+      fi
+      ( set -x ; dd if="''${deviceFirmwareFile[0]}" of="$flashDevice" )
+
+      echo "Firmware copy for $part complete."
+      echo
+
+      declare -i deviceResetWait=0
+      while :; do
+          updateUF2Devices
+          if [ "''${#uf2devices[@]}" -eq 0 ]; then
+            break
+          fi
+          case "$deviceResetWait" in
+            0 | 1 | 2)
+              ;;
+            3)
+              echo -n "Waiting for device to exit bootloader mode"
+              ;;
+            *)
+              echo -n "."
+          esac
+          deviceResetWait+=1
+          sleep 1
+      done
+      if [ "$deviceResetWait" -gt 2 ]; then
+        echo
+      fi
+
+    done
+
+    echo "Flashing complete, terminating"
+  '';
+
+  meta = with lib; {
+    description = "ZMK UF2 firmware flasher";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/nix/uf2-udev-rules/default.nix
+++ b/nix/uf2-udev-rules/default.nix
@@ -1,0 +1,21 @@
+{ lib, stdenv }:
+
+stdenv.mkDerivation rec {
+  pname = "uf2-udev-rules";
+  version = "20240627";
+
+  src = [ ./uf2-block.rules ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    install -Dpm644 $src $out/lib/udev/rules.d/99-uf2-block.rules
+  '';
+
+  meta = with lib; {
+    description = "udev rules that give all users permission to write to UF2 bootloader block devices";
+    platforms = platforms.linux;
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/nix/uf2-udev-rules/uf2-block.rules
+++ b/nix/uf2-udev-rules/uf2-block.rules
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+
+SUBSYSTEM!="block", GOTO="uf2_block_end"
+# UF2 bootloaders are always USB devices
+ENV{ID_BUS}!="usb", GOTO="uf2_block_end"
+
+# The write target always has a vfat filesystem.
+# Some devices, such as Nice!Nano, have no partition and just a block device
+# Other devices, such as RP2040's, have a partition that should be the target instead
+ENV{ID_FS_TYPE}!="vfat", GOTO="uf2_block_end"
+ENV{ID_FS_USAGE}!="filesystem", GOTO="uf2_block_end"
+
+#### DEVICE BOOTLOADERS
+
+# Nice!Nano Bootloader
+ENV{ID_VENDOR}=="Adafruit", ENV{ID_MODEL}=="nRF_UF2", GOTO="permissive_uf2_bootloader"
+
+# RP2 (RP2040, RPiPico, SparkFun Pro Micro RP2040, etc)
+ENV{ID_VENDOR}=="RPI", ENV{ID_MODEL}=="RP2", GOTO="permissive_uf2_bootloader"
+
+#### END DEVICE BOOTLOADERS
+
+# No device matched, jump to the end to prevent assignments to these unrelated devices.
+GOTO="uf2_block_end"
+
+LABEL="permissive_uf2_bootloader"
+# Symlink provides a very well known location to look for flashable devices.
+SYMLINK="mapper/uf2_bootloader_$env{ID_SERIAL_SHORT}"
+# Yes, other r/w.  The hardware has to be put into bootloader mode via physical interaction
+# so it's probably fine.
+MODE="0666"
+
+LABEL="uf2_block_end"

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,29 @@ The `buildSplitKeyboard` function takes the following arguments and outputs a di
 * `extraCmakeFlags` - list of extra CMake flags to pass to the ZMK build, defaults to `[]`
 
 
+## Flashers
+
+All flashers take the following arguments.
+
+* `firmware` - Derivation of one of the *builders*.
+
+### `flash` (default)
+
+The `flash` function flashes nRF devices that use an Adafruit bootloader.
+After placing the device into bootloader mode the user is required to mount the vfat filesystem in a manner the user running the flash script is allowed to copy a file to the device.
+
+### `flashBlock`
+
+The `flashBlock` function flashes UF2 bootloaders by directly writing the new firmware to the UF2 to the block device.
+This requires no user interaction after initial UDEV setup, and prevents a mounted filesystem from disappearing.
+This requires a *UDEV Rule*, which can be included in nixos by adding the `zmk-nix.nixosModules.udevRules` to the nixosSystem modules.
+On non-nixos systems, [uf2-block.rules](./nix/uf2-udev-rules/uf2-block.rules) to `/etc/udev/rules.d`.
+The udev rule currently supports:
+
+* Adafruit nRF UF2 bootloaders
+* RP2 bootloaders (RP2040)
+
+
 ## Packages
 
 ### `firmware`


### PR DESCRIPTION
This is an alternative to https://github.com/lilyinstarlight/zmk-nix/pull/80, however they are not mutually exclusive and both could be adopted.

This method takes advantage of the fact that you can send the UF2 firmware to the microcontroller by simply writing it to the block device the firmware exposes, without mounting the vfat filesystem.  This avoids the microcontroller causing issues when it abruptly disappears as soon as the file copy is complete, rather than waiting for the filesystem to be unmounted and the device ejected.

~I still need to write documentation for this, and I plan to update this PR with a commit adding that documentation.~

Setup is as follows:

First is the installation of the udev rule.  On NixOS that can be done by using the new nixosModule output.

```nix
{
  ...
  inputs.zmk-nix.url = "github:lilyinstarlight/zmk-nix";

  outputs = {
    zmk-nix,
    ...
  }: {
    nixosConfigurations = {
      myHost = nixosSystem {
        ...
        modules = [
          zmk-nix.nixosModules.udevRules
        ];
        ...
      };
    };
  };
}
```

For Non-NixOS use, the user should copy the uf2-block.rules file to
/etc/udev/rules.d/{priority}-uf2-block.rules.


Then change the flash command in the user zmk-config:
```
flash = zmk-nix.packages.${system}.flashBlock.override { inherit firmware; };
```
