### PR TITLE
nix-shell: Add keymap-drawer and flash packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   outputs = { self, nixpkgs }: let
     forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-  in {
+  in rec {
     lib = {
       buildersFor = pkgs: import ./nix/builders.nix { inherit (pkgs) callPackage; };
     };
@@ -30,7 +30,7 @@
     };
 
     devShells = forAllSystems (system: let pkgs = nixpkgs.legacyPackages.${system}; in {
-      default = pkgs.callPackage ./nix/shell.nix {};
+      default = pkgs.callPackage ./nix/shell.nix {extra-pkgs = [packages.${system}.flash];};
     });
 
     templates = {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -3,8 +3,77 @@
 , ninja
 , gcc-arm-embedded
 , python3
+, python3Packages
+, lib
+, fetchFromGitHub
+, extra-pkgs ? []
 }:
 
+let
+  # Keymap-drawer uses version 3 of `platformdirs` but NixPkgst only has
+  # version 4.2 available. It's easier to brging the package from GitHub than
+  # creating a flake input for an old version of NixPkgs, just to get this one
+  # dependency
+  platformdirs3 = python3Packages.buildPythonPackage rec {
+    name = "platformdirs";
+    version = "3.11.0";
+
+    src = fetchFromGitHub {
+      owner = "platformdirs";
+      repo = "${name}";
+      rev = "${version}";
+      sha256 = "sha256-rMPpxwPbqAtvr3RtKQDisqQnCxnBfZdolMUPpDE+tR4=";
+    };
+
+    format = "pyproject";
+
+    nativeBuildInputs = [
+      python3Packages.hatchling
+      python3Packages.hatch-vcs
+    ];
+
+    meta = {
+      homepage = "https://github.com/platformdirs/platformdirs/tree/3.11.0";
+      description = "A small Python module for determining appropriate platform-specific dirs";
+      license = lib.licenses.mit;
+    };
+  };
+
+  # NixPkgs does not offer `keymap-drawer` as a python package nor a
+  # stand-alone application, so we have  pull the package into our environment
+  keymap-drawer = python3Packages.buildPythonPackage rec {
+    name = "keymap-drawer";
+    version = "v0.17.0";
+
+    src = fetchFromGitHub {
+      owner = "caksoylar";
+      repo = "${name}";
+      rev = "main";
+      sha256 = "sha256-eyCOkoVjK32cbLmC+Vgrge5ikW9nhxWc0XElUa76Ksw=";
+    };
+
+    format = "pyproject";
+
+    nativeBuildInputs = [
+      python3Packages.poetry-core
+    ];
+
+    propagatedBuildInputs = with python3Packages; [
+      pcpp
+      platformdirs3
+      pydantic
+      pydantic-settings
+      pyparsing
+      pyyaml
+    ];
+
+    meta = {
+      homepage = "https://github.com/caksoylar/keymap-drawer";
+      description = "Visualize keymaps that use advanced features like hold-taps and combos, with automatic parsing ";
+      license = lib.licenses.mit;
+    };
+  };
+in
 mkShell {
   packages = [
     cmake ninja
@@ -23,9 +92,11 @@ mkShell {
       ps.requests
       ps.anytree
       ps.intelhex
+      keymap-drawer
     ]))
     gcc-arm-embedded
-  ];
+  ]
+  ++ extra-pkgs;
 
   env = {
     ZEPHYR_TOOLCHAIN_VARIANT = "gnuarmemb";


### PR DESCRIPTION
This commit adds the `keymap-drawer` utility to the dev shell so we can generate layout map images of our configuration. It also adds the `flash` package from the flake as a binary, so one can simply call `zmk-uf2-flash` inside a dev shell to flash the firmware built by the flake.