### PR TITLE
ci/deps: add permission to create pull request

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   update:
     name: Update

--- a/template/.github/workflows/deps.yml
+++ b/template/.github/workflows/deps.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   update:
     name: Update
@@ -16,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/nix-installer-action@v11
+      - uses: DeterminateSystems/nix-installer-action@v12
 
       - run: nix -vL run --show-trace .#update
 


### PR DESCRIPTION
GitHub some time ago change the default settings for repository, which now explicitly require having this permission to be enabled in github actions.