### PR TITLE
nix/zmk: fix nanopb executability for zmk studio builds

### DIFF
--- a/nix/zmk/keyboard.nix
+++ b/nix/zmk/keyboard.nix
@@ -50,10 +50,12 @@
     elif [ -e boards ]; then
       westBuildFlagsArray+=("-DBOARD_ROOT=$(readlink -f .)")
     fi
-
-    if [ -d modules/lib/nanopb/generator ]; then
-      chmod +x modules/lib/nanopb/generator/{nanopb_generator,protoc,protoc-gen-nanopb}
-      patchShebangs modules/lib/nanopb/generator
-    fi
   '' + (args.preConfigure or "");
+
+  postConfigure = ''
+    if [ -d ../modules/lib/nanopb/generator ]; then
+      chmod +x ../modules/lib/nanopb/generator/{nanopb_generator,protoc,protoc-gen-nanopb}
+      patchShebangs ../modules/lib/nanopb/generator
+    fi
+  '';
 })

--- a/nix/zmk/keyboard.nix
+++ b/nix/zmk/keyboard.nix
@@ -57,5 +57,5 @@
       chmod +x ../modules/lib/nanopb/generator/{nanopb_generator,protoc,protoc-gen-nanopb}
       patchShebangs ../modules/lib/nanopb/generator
     fi
-  '';
+  '' + (args.postConfigure or "");
 })


### PR DESCRIPTION
Builds with Zmk Studio enabled were failing when compiling protocol buffers due to `protoc-gen-nanopb: program not found or is not executable`.

> [18/368] Running C++ protocol buffer compiler using nanopb plugin on /build/tmp.Srk3h9ssKA/modules/msgs/zmk-studio-messages/proto/zmk/studio.proto
FAILED: proto/zmk/studio.pb.c proto/zmk/studio.pb.h /build/tmp.Srk3h9ssKA/build/proto/zmk/studio.pb.c /build/tmp.Srk3h9ssKA/build/proto/zmk/studio.pb.h 
cd /build/tmp.Srk3h9ssKA/build && /nix/store/90zvvvrx43i07iwza86pvvl94nygxf2n-protobuf-28.2/bin/protoc -I/build/tmp.Srk3h9ssKA/modules/msgs/zmk-studio-messages -I/build/tmp.Srk3h9ssKA/modules/msgs/zmk-studio-messages/proto/zmk -I/build/tmp.Srk3h9ssKA/build/nanopb/generator -I/build/tmp.Srk3h9ss>
/build/tmp.Srk3h9ssKA/build/nanopb/generator/protoc-gen-nanopb: program not found or is not executable
Please specify a program using absolute path or make sure the program is available in your PATH system variable
--nanopb_out: protoc-gen-nanopb: Plugin failed with status code 1.

For some reason the `nanopb` files don't exist during `preConfigure` stage anymore so I moved the pre-processing of the `nanopb` scripts to postConfigure and that seems to have fixed the issue for me.

I'm not sure that this is the best approach to fix this, any better suggestions would be great!

Also, the zmk studio builds, while they now techically build, don't work for some reason. Zmk Studio can connect but doesn't show any keys. The browser console shows some RPC errors like the following:
> RPC Error Mismatch request IDs
       (anonymous) @ index-zkUEy1nq.js:49

