### PR TITLE
added `CONFIG_ZMK_STUDIO` CMake flag when `enableZmkStudio` is set

### DIFF
--- a/nix/zmk/keyboard.nix
+++ b/nix/zmk/keyboard.nix
@@ -30,8 +30,9 @@
     "-b" board
   ] ++ extraWestBuildFlags ++ lib.optionals enableZmkStudio [ "-S" "studio-rpc-usb-uart" ] ++ [
     "--"
-  ] ++ lib.optional (shield != null) "-DSHIELD=${shield}" ++ extraCmakeFlags;
-
+  ] ++ lib.optional (shield != null) "-DSHIELD=${shield}" 
+    ++ lib.optional enableZmkStudio "-DCONFIG_ZMK_STUDIO=y" 
+    ++ extraCmakeFlags;
   postPatch = ''
     if [ -e zephyr/module.yml ]; then
       zmkModuleRoot="$(readlink -f .)"


### PR DESCRIPTION
Thanks for this project @lilyinstarlight, it is **amazing** 🤩

I was trying to activate ZMK-Studio with this repo and I noticed that the `enableZmkStudio` option was not enough by itself

I looked through [the docs](https://zmk.dev/docs/features/studio#local-build) and saw that ZMK Studio also requires setting the `ZMK_STUDIO` Kconfig setting. You **could** add that to your Kconfig file, but alternatively you can just add an extra CMake flag `-DCONFIG_ZMK_STUDIO=y`

I tested it with `extraCmakeFlags` in [my config file](https://github.com/imochoa/ferris-sweep-zmk-nix/blob/0c44b281b03c39017faef229ab8ae3c4ee7f0fb1/flake.nix#L46-L47) and that fixed it, so I thought it might be a good idea to have it automatically set when using `enableZmkStudio` :)